### PR TITLE
Fix Dockerfile backend copy paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ FROM python:3.9-slim
 WORKDIR /app
 
 # Install dependencies
-COPY api/requirements.txt .
+COPY news-suite/api/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy backend code
-COPY api /app
+COPY news-suite/api /app
 
 # Start backend service
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- update the Dockerfile to copy the backend sources from the news-suite/api directory
- ensure dependency installation points to the same location for requirements

## Testing
- docker build -t news-api-test . *(fails: `docker` command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d7c1343c8328b65f826e2fd115ef