### PR TITLE
Replace supabase dependency with available package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ FROM python:3.9-slim
 WORKDIR /app
 
 # Install dependencies
-COPY api/requirements.txt .
+COPY news-suite/api/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy backend code
-COPY api /app
+COPY news-suite/api /app
 
 # Start backend service
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/news-suite/api/requirements.txt
+++ b/news-suite/api/requirements.txt
@@ -4,4 +4,4 @@ apscheduler
 readability-lxml
 stripe
 redis
-supabase-py
+supabase

--- a/start.sh
+++ b/start.sh
@@ -1,17 +1,31 @@
-# start.sh
 #!/bin/bash
 set -euo pipefail
 
 # 启动后端服务
 PORT="${PORT:-8000}"
-if [ -d "api" ]; then
-  cd api
-  uvicorn app:app --host 0.0.0.0 --port "$PORT" &
-  cd ..
+API_DIR="news-suite/api"
+LEGACY_API_DIR="api"
+
+if [ -d "$API_DIR" ]; then
+  (
+    cd "$API_DIR"
+    uvicorn app:app --host 0.0.0.0 --port "$PORT" &
+  )
+elif [ -d "$LEGACY_API_DIR" ]; then
+  (
+    cd "$LEGACY_API_DIR"
+    uvicorn app:app --host 0.0.0.0 --port "$PORT" &
+  )
 fi
 
 # 启动前端服务
-if [ -d "web" ]; then
-  cd web
+WEB_DIR="news-suite/web"
+LEGACY_WEB_DIR="web"
+
+if [ -d "$WEB_DIR" ]; then
+  cd "$WEB_DIR"
+  npm run start
+elif [ -d "$LEGACY_WEB_DIR" ]; then
+  cd "$LEGACY_WEB_DIR"
   npm run start
 fi


### PR DESCRIPTION
## Summary
- update the backend requirements to depend on the `supabase` package instead of the unavailable `supabase-py`
- adjust the backend Dockerfile paths to copy the code and requirements from `news-suite/api`
- update the project start script to work with the `news-suite` directory layout

## Testing
- pip install -r news-suite/api/requirements.txt
- bash -n start.sh

------
https://chatgpt.com/codex/tasks/task_e_68d4d7c1343c8328b65f826e2fd115ef